### PR TITLE
Convert install path to be relative for manpages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'scripts/medic',
     ],
     data_files=[
-        ('/usr/local/share/man/man1', ['medic.1']),
+        ('share/man/man1', ['medic.1']),
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This allows installation in virtualenv environments for regular users.
Prior to this change, a user would have hit a "permission denied" error
similar to:
    creating /usr/local/share/man/man1

```
error: could not create '/usr/local/share/man/man1': Permission denied
```
